### PR TITLE
Add training control Flask API

### DIFF
--- a/src/ui/api/__init__.py
+++ b/src/ui/api/__init__.py
@@ -1,0 +1,12 @@
+from flask import Blueprint
+
+from .training import training_bp
+from .mesh import mesh_bp
+
+
+def register_blueprints(app):
+    app.register_blueprint(training_bp)
+    app.register_blueprint(mesh_bp)
+
+
+__all__ = ["register_blueprints", "training_bp", "mesh_bp"]

--- a/src/ui/api/mesh.py
+++ b/src/ui/api/mesh.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, jsonify, request
+
+from src.utils import MeshImporter
+
+mesh_bp = Blueprint("mesh", __name__, url_prefix="/mesh")
+importer = MeshImporter()
+
+
+@mesh_bp.route("/list", methods=["GET"])
+def list_meshes():
+    subfolder = request.args.get("subfolder", "mesh")
+    meshes = importer.list_available_meshes(subfolder)
+    return jsonify({"meshes": meshes})
+
+
+@mesh_bp.route("/info/<name>", methods=["GET"])
+def mesh_info(name: str):
+    subfolder = request.args.get("subfolder", "mesh")
+    info = importer.get_mesh_info(name, subfolder)
+    return jsonify(info)

--- a/src/ui/api/training.py
+++ b/src/ui/api/training.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, request, jsonify
+
+from src.ui.training_manager import TrainingManager
+
+training_manager = TrainingManager()
+
+training_bp = Blueprint("training", __name__, url_prefix="/training")
+
+
+@training_bp.route("/start", methods=["POST"])
+def start_training():
+    data = request.get_json(force=True, silent=True) or {}
+    mesh_name = data.get("mesh_name")
+    subfolder = data.get("subfolder", "mesh")
+    episodes = data.get("max_episodes")
+    steps = data.get("max_steps")
+    try:
+        training_manager.start_training(
+            mesh_name=mesh_name,
+            subfolder=subfolder,
+            max_episodes=episodes,
+            max_steps=steps,
+        )
+        return jsonify({"message": "training_started"})
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+
+@training_bp.route("/stop", methods=["POST"])
+def stop_training():
+    training_manager.stop_training()
+    return jsonify({"message": "stop_requested"})
+
+
+@training_bp.route("/status", methods=["GET"])
+def status():
+    return jsonify(training_manager.get_status())

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,0 +1,15 @@
+from flask import Flask
+
+from src.ui.api import register_blueprints
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    register_blueprints(app)
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/src/ui/training_manager.py
+++ b/src/ui/training_manager.py
@@ -1,0 +1,69 @@
+import threading
+from typing import Optional, Dict, Any
+
+from src.rl.trainer import MeshTrainer
+from src.utils import MeshImporter
+
+
+class TrainingManager:
+    """Manage asynchronous training sessions."""
+
+    def __init__(self) -> None:
+        self._trainer: Optional[MeshTrainer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._status: str = "idle"
+        self._stats: Optional[Dict[str, Any]] = None
+        self.importer = MeshImporter()
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start_training(
+        self,
+        mesh_name: Optional[str] = None,
+        subfolder: str = "mesh",
+        max_episodes: Optional[int] = None,
+        max_steps: Optional[int] = None,
+    ) -> None:
+        if self.running:
+            raise RuntimeError("Training already running")
+
+        if mesh_name is None:
+            self._trainer = MeshTrainer()
+        else:
+            self._trainer = MeshTrainer.from_mesh_name(mesh_name, subfolder=subfolder)
+
+        self._stop_event.clear()
+        self._stats = None
+        self._status = "running"
+
+        def _run() -> None:
+            try:
+                self._stats = self._trainer.train(
+                    max_episodes=max_episodes,
+                    max_steps=max_steps,
+                    stop_event=self._stop_event,
+                )
+                if self._stop_event.is_set():
+                    self._status = "stopped"
+                else:
+                    self._status = "completed"
+            finally:
+                pass
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+
+    def stop_training(self) -> None:
+        if not self.running:
+            return
+        self._stop_event.set()
+
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "running": self.running,
+            "status": self._status,
+            "stats": self._stats,
+        }


### PR DESCRIPTION
## Summary
- implement async training management helper
- add training and mesh API blueprints for Flask
- wire blueprints into API package
- create application entrypoint
- support early stopping in `MeshTrainer`

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68698023aeac832a878de5bbe774c3b7