### PR TITLE
Fix mesh rendering when API returns JSON strings

### DIFF
--- a/src/ui/training_manager.py
+++ b/src/ui/training_manager.py
@@ -94,7 +94,8 @@ class TrainingManager:
             'boundary_vertices': 0,
             'buffer_size': 0,
             'mesh_data': {},
-            'boundary_vertices_data': []
+            'boundary_vertices_data': [],
+            'reference_point_info': None
         }
         self._status = "running"
 
@@ -169,6 +170,14 @@ class TrainingManager:
                 print(f"处理boundary_vertices时发生错误: {boundary_error}")
                 serializable_boundary_vertices = []
 
+            # 处理参考点信息
+            ref_info = episode_data.get('reference_point_info')
+            try:
+                serializable_ref_info = self._deep_clean_for_json(ref_info)
+            except Exception as ref_err:
+                print(f"处理reference_point_info时发生错误: {ref_err}")
+                serializable_ref_info = None
+
             # 更新实时统计信息
             self._stats.update({
                 'episode': episode_data.get('episode', 0),
@@ -179,7 +188,8 @@ class TrainingManager:
                 'boundary_vertices': episode_data.get('boundary_size', 0),
                 'buffer_size': episode_data.get('buffer_size', 0),
                 'mesh_data': serializable_mesh_data,
-                'boundary_vertices_data': serializable_boundary_vertices
+                'boundary_vertices_data': serializable_boundary_vertices,
+                'reference_point_info': serializable_ref_info
             })
 
             # 添加最近的损失信息，确保是可序列化的浮点数
@@ -202,7 +212,8 @@ class TrainingManager:
                 'boundary_vertices': 0,
                 'buffer_size': 0,
                 'mesh_data': {},
-                'boundary_vertices_data': []
+                'boundary_vertices_data': [],
+                'reference_point_info': None
             }
 
     def stop_training(self) -> None:
@@ -324,6 +335,7 @@ class TrainingManager:
                     'boundary_vertices': 0,
                     'buffer_size': 0,
                     'mesh_data': {},
-                    'boundary_vertices_data': []
+                    'boundary_vertices_data': [],
+                    'reference_point_info': None
                 }
             }

--- a/tools/js/train.js
+++ b/tools/js/train.js
@@ -512,30 +512,59 @@ class TrainingManager {
      * 更新训练统计数据
      */
     updateTrainingStats(stats) {
-        if (!this.statsContainer) return;
-
         const formatNumber = (num) => (num !== undefined && num !== null) ? num.toFixed(3) : 'N/A';
 
-        this.statsContainer.innerHTML = `
-            <span>Episode: ${stats.episode || 'N/A'}</span>
-            <span>Episode奖励: ${formatNumber(stats.episode_reward)}</span>
-            <span>平均奖励: ${formatNumber(stats.average_reward)}</span>
-            <span>Episode长度: ${stats.episode_length || 'N/A'}</span>
-            <span>边界顶点: ${stats.boundary_vertices || 'N/A'}</span>
-            <span>Buffer大小: ${stats.buffer_size || 'N/A'}</span>
-            <span>Actor Loss: ${formatNumber(stats.recent_actor_loss)}</span>
-            <span>Critic Loss: ${formatNumber(stats.recent_critic_loss)}</span>
-            <span>Alpha: ${formatNumber(stats.current_alpha)}</span>
-        `;
+        // 如果页面中存在statsContainer，则更新其内容
+        if (this.statsContainer) {
+            this.statsContainer.innerHTML = `
+                <span>Episode: ${stats.episode || 'N/A'}</span>
+                <span>Episode奖励: ${formatNumber(stats.episode_reward)}</span>
+                <span>平均奖励: ${formatNumber(stats.average_reward)}</span>
+                <span>Episode长度: ${stats.episode_length || 'N/A'}</span>
+                <span>边界顶点: ${stats.boundary_vertices || 'N/A'}</span>
+                <span>Buffer大小: ${stats.buffer_size || 'N/A'}</span>
+                <span>Actor Loss: ${formatNumber(stats.recent_actor_loss)}</span>
+                <span>Critic Loss: ${formatNumber(stats.recent_critic_loss)}</span>
+                <span>Alpha: ${formatNumber(stats.current_alpha)}</span>
+            `;
+        }
 
         // 新增：处理参考点信息
         if (stats.reference_point_info) {
             this.refPointInfo = stats.reference_point_info;
+
+            const refEl = document.getElementById('ref-point');
+            if (refEl && stats.reference_point_info.ref_vertex) {
+                const [rx, ry] = stats.reference_point_info.ref_vertex;
+                refEl.textContent = `(${formatNumber(rx)}, ${formatNumber(ry)})`;
+            }
+        } else {
+            const refEl = document.getElementById('ref-point');
+            if (refEl) refEl.textContent = 'N/A';
         }
 
         // 统一渲染mesh和boundary数据，避免坐标变换不一致导致的错位问题
-        const meshData = stats.mesh_data || this.meshData;
-        const boundaryData = stats.boundary_vertices_data || this.boundaryData;
+        let meshData = stats.mesh_data || this.meshData;
+        let boundaryData = stats.boundary_vertices_data || this.boundaryData;
+
+        // 如果后端返回的mesh或boundary数据是字符串，尝试解析
+        try {
+            if (typeof meshData === 'string') {
+                meshData = JSON.parse(meshData);
+            }
+        } catch (e) {
+            console.error('解析mesh数据失败:', e);
+            meshData = null;
+        }
+
+        try {
+            if (typeof boundaryData === 'string') {
+                boundaryData = JSON.parse(boundaryData);
+            }
+        } catch (e) {
+            console.error('解析boundary数据失败:', e);
+            boundaryData = null;
+        }
 
         if (meshData || boundaryData) {
             this.meshData = meshData;
@@ -548,7 +577,28 @@ class TrainingManager {
      * 统一渲染Mesh和Boundary，避免坐标变换不一致导致的错位问题
      */
     renderMeshAndBoundary(meshData, boundaryVertices) {
+        // 兼容后端可能返回字符串的情况
+        try {
+            if (typeof meshData === 'string') {
+                meshData = JSON.parse(meshData);
+            }
+        } catch (e) {
+            console.error('解析mesh数据失败:', e);
+            meshData = null;
+        }
+
+        try {
+            if (typeof boundaryVertices === 'string') {
+                boundaryVertices = JSON.parse(boundaryVertices);
+            }
+        } catch (e) {
+            console.error('解析boundary数据失败:', e);
+            boundaryVertices = null;
+        }
+
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        // 重新绘制背景网格
+        this.drawGrid();
 
         const allVertices = [];
         if (boundaryVertices) {

--- a/tools/train.html
+++ b/tools/train.html
@@ -143,6 +143,10 @@
                         <span class="text-gray-600">Episode长度:</span>
                         <span id="episode-length" class="font-semibold text-gray-800">0</span>
                     </div>
+                    <div class="text-sm">
+                        <span class="text-gray-600">参考点:</span>
+                        <span id="ref-point" class="font-semibold text-gray-800">N/A</span>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- handle mesh/boundary data returned as JSON strings from backend
- draw grid when re-rendering canvas
- always render mesh even if stats container is absent
- include reference point info in training status
- display current reference point in UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869c8e5f398832abd88dad817f12558