### PR TITLE
Translate frontend interface to English

### DIFF
--- a/tools/canvas.html
+++ b/tools/canvas.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>交互式画板</title>
+    <title>Interactive Canvas</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -40,7 +40,7 @@
 <div class="w-full max-w-6xl h-full flex flex-col bg-white rounded-2xl shadow-2xl overflow-hidden">
     <!-- Header / Controls -->
     <header class="flex flex-wrap items-center justify-between p-4 border-b border-gray-200 bg-gray-50">
-        <h1 class="text-xl md:text-2xl font-bold text-gray-800">交互式画板</h1>
+        <h1 class="text-xl md:text-2xl font-bold text-gray-800">Interactive Canvas</h1>
         <div class="flex items-center space-x-2 md:space-x-4">
             <div class="flex items-center space-x-2 bg-indigo-100 text-indigo-800 text-sm font-semibold px-3 py-1.5 rounded-full">
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
@@ -48,12 +48,12 @@
                     <circle cx="12" cy="12" r="10"></circle>
                     <circle cx="12" cy="12" r="3"></circle>
                 </svg>
-                <span>点数量: <span id="point-counter">0</span></span>
+                <span>Points: <span id="point-counter">0</span></span>
             </div>
-            <button id="finish-btn" class="btn btn-success">完成绘制</button>
-            <button id="export-btn" class="btn btn-secondary" disabled>导出.txt</button>
-            <button id="import-btn" class="btn">导入.txt</button>
-            <button id="reset-btn" class="btn btn-danger">重置</button>
+            <button id="finish-btn" class="btn btn-success">Finish Drawing</button>
+            <button id="export-btn" class="btn btn-secondary" disabled>Export .txt</button>
+            <button id="import-btn" class="btn">Import .txt</button>
+            <button id="reset-btn" class="btn btn-danger">Reset</button>
         </div>
     </header>
 
@@ -62,12 +62,12 @@
         <canvas id="main-canvas"></canvas>
         <div id="instructions"
              class="absolute top-4 left-4 bg-white/80 backdrop-blur-sm p-3 rounded-lg text-gray-600 text-sm shadow-md pointer-events-none">
-            <p> - 在画板上点击以添加点。</p>
-            <p> - 按 <kbd
+            <p> - Click on the canvas to add a point.</p>
+            <p> - Press <kbd
                     class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">Ctrl</kbd>
                 +
                 <kbd class="px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg">Z</kbd>
-                撤销上一个点。</p>
+                undo the last point.</p>
         </div>
         <div id="message-box"
              class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-red-500 text-white px-6 py-3 rounded-lg shadow-xl">
@@ -212,7 +212,7 @@
         importFileInput.value = ''; // Clear file input
         updateUI();
         draw();
-        showMessage("画板已重置", 1500);
+        showMessage("Canvas reset", 1500);
     }
 
     // --- Event Handlers ---
@@ -222,7 +222,7 @@
      */
     function handleCanvasClick(event) {
         if (isFinished) {
-            showMessage("已完成绘制，请先重置再开始新的绘制。", 2500);
+            showMessage("Drawing finished. Please reset before starting a new one.", 2500);
             return;
         }
         const rect = canvas.getBoundingClientRect();
@@ -241,7 +241,7 @@
      */
     function handleFinish() {
         if (points.length < 3) {
-            showMessage("请至少绘制3个点才能完成。", 2000);
+            showMessage("Please draw at least 3 points to finish.", 2000);
             return;
         }
         isFinished = true;
@@ -302,20 +302,20 @@
                     .filter(line => line.length > 0 && !line.startsWith('#'));
 
                 if (lines.length === 0) {
-                    throw new Error("文件内容为空或只包含注释。");
+                    throw new Error("File is empty or only contains comments.");
                 }
 
                 const importedPoints = lines.map(line => {
                     const parts = line.split(/\s+/);
-                    if (parts.length !== 2) throw new Error("文件格式错误：每一行应包含两个由空格分隔的数字。");
+                    if (parts.length !== 2) throw new Error("File format error: each line must contain two numbers separated by space.");
                     const x = parseFloat(parts[0]);
                     const y = parseFloat(parts[1]);
-                    if (isNaN(x) || isNaN(y)) throw new Error("文件内容错误：坐标必须是数字。");
+                    if (isNaN(x) || isNaN(y)) throw new Error("File content error: coordinates must be numbers.");
                     return {x, y};
                 });
 
                 if (importedPoints.length < 2) {
-                    throw new Error("导入失败：文件至少需要包含2个点。");
+                    throw new Error("Import failed: file must contain at least 2 points.");
                 }
 
                 // --- Auto-zoom and Center Logic ---
@@ -348,7 +348,7 @@
 
                 updateUI();
                 draw();
-                showMessage("文件导入成功！", 2000);
+                showMessage("File imported successfully!", 2000);
 
             } catch (error) {
                 resetState(); // Reset if import fails
@@ -361,7 +361,7 @@
         };
 
         reader.onerror = function () {
-            showMessage("读取文件时发生错误。", 3000);
+            showMessage("An error occurred while reading the file.", 3000);
         };
 
         reader.readAsText(file);

--- a/tools/history.html
+++ b/tools/history.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>训练历史记录查看器</title>
+    <title>Training History Viewer</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="css/history.css">
     <script>
@@ -29,8 +29,8 @@
     <div class="history-left-panel shadow-lg">
         <!-- 头部 -->
         <div class="p-6 border-b border-gray-200">
-            <h1 class="text-2xl font-bold text-gray-800">训练历史</h1>
-            <p class="text-sm text-gray-600 mt-1">查看历史训练记录和详细数据</p>
+            <h1 class="text-2xl font-bold text-gray-800">Training History</h1>
+            <p class="text-sm text-gray-600 mt-1">View past training sessions and details</p>
         </div>
 
         <!-- 控制区域 -->
@@ -39,39 +39,39 @@
             <div class="mb-6 space-y-3">
                 <button id="refresh-history-btn"
                         class="w-full bg-primary hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200">
-                    刷新列表
+                    Refresh List
                 </button>
                 <button id="health-check-btn"
                         class="w-full bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200">
-                    服务状态检查
+                    Check Service
                 </button>
             </div>
 
             <!-- 训练会话列表 -->
             <div class="mb-6 flex-1 overflow-y-auto custom-scrollbar training-list-container">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">训练会话列表</h3>
+                <h3 class="text-sm font-medium text-gray-700 mb-3">Training Sessions</h3>
                 <div id="training-list" class="space-y-2">
                     <div class="text-center text-gray-500 py-4">
                         <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary mx-auto mb-2"></div>
-                        <div>加载中...</div>
+                        <div>Loading...</div>
                     </div>
                 </div>
             </div>
 
             <!-- 当前选中的训练信息 -->
             <div id="current-training-info" class="hidden">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">训练摘要</h3>
+                <h3 class="text-sm font-medium text-gray-700 mb-3">Training Summary</h3>
                 <div class="bg-white rounded-lg p-4 border border-gray-200 space-y-2">
                     <div class="flex justify-between text-sm">
-                        <span class="text-gray-600">训练ID:</span>
+                        <span class="text-gray-600">Training ID:</span>
                         <span id="training-id-display" class="font-medium text-gray-800 text-xs">-</span>
                     </div>
                     <div class="flex justify-between text-sm">
-                        <span class="text-gray-600">总Episodes:</span>
+                        <span class="text-gray-600">Total Episodes:</span>
                         <span id="detail-length-display" class="font-medium text-gray-800">-</span>
                     </div>
                     <div class="flex justify-between text-sm">
-                        <span class="text-gray-600">最佳Episode:</span>
+                        <span class="text-gray-600">Best Episode:</span>
                         <span id="best-episode-display" class="font-medium text-gray-800">-</span>
                     </div>
                 </div>
@@ -79,34 +79,34 @@
 
             <!-- Episode导航 -->
             <div id="episode-navigation" class="hidden mt-6">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">Episode导航</h3>
+                <h3 class="text-sm font-medium text-gray-700 mb-3">Episode Navigation</h3>
                 <div class="space-y-3">
                     <div class="flex items-center space-x-2">
                         <input id="episode-index-input" type="number" min="0" value="0"
                                class="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
                         <button id="goto-episode-btn"
                                 class="bg-secondary hover:bg-purple-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200">
-                            查看
+                            View
                         </button>
                     </div>
                     <div class="flex space-x-2">
                         <button id="goto-best-episode-btn"
                                 class="flex-1 bg-success hover:bg-green-600 text-white font-medium py-2 px-3 rounded-lg transition-colors duration-200 text-sm">
-                            最佳Episode
+                            Best Episode
                         </button>
                         <button id="goto-last-episode-btn"
                                 class="flex-1 bg-warning hover:bg-orange-600 text-white font-medium py-2 px-3 rounded-lg transition-colors duration-200 text-sm">
-                            最后Episode
+                            Last Episode
                         </button>
                     </div>
                     <div class="flex space-x-2">
                         <button id="prev-episode-btn"
                                 class="flex-1 bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-3 rounded-lg transition-colors duration-200 text-sm">
-                            上一个
+                            Previous
                         </button>
                         <button id="next-episode-btn"
                                 class="flex-1 bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-3 rounded-lg transition-colors duration-200 text-sm">
-                            下一个
+                            Next
                         </button>
                     </div>
                 </div>
@@ -120,33 +120,33 @@
         <div class="history-top-info-bar shadow-sm">
             <div class="flex items-center justify-between flex-wrap gap-4">
                 <div>
-                    <h2 class="text-lg font-semibold text-gray-800">Episode详情</h2>
+                    <h2 class="text-lg font-semibold text-gray-800">Episode Details</h2>
                     <p class="text-sm text-gray-600">
-                        <span id="current-episode-display">未选择Episode</span>
+                        <span id="current-episode-display">No Episode Selected</span>
                         <span id="episode-meta-info" class="hidden">
-                            - 实际Episode: <span id="actual-episode-number-display">N/A</span>
-                            - 奖励: <span id="episode-reward-display">0.000</span>
-                            - 长度: <span id="episode-length-display">0</span>步
-                            - 状态: <span id="episode-status-display">未知</span>
+                            - Actual Episode: <span id="actual-episode-number-display">N/A</span>
+                            - Reward: <span id="episode-reward-display">0.000</span>
+                            - Length: <span id="episode-length-display">0</span> steps
+                            - Status: <span id="episode-status-display">Unknown</span>
                         </span>
                     </p>
                 </div>
                 <div class="flex items-center space-x-4 flex-wrap">
                     <div class="text-sm">
-                        <span class="text-gray-600">边界顶点:</span>
+                        <span class="text-gray-600">Boundary Vertices:</span>
                         <span id="boundary-vertices-count" class="font-semibold text-gray-800">0</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">网格顶点:</span>
+                        <span class="text-gray-600">Mesh Vertices:</span>
                         <span id="mesh-vertices-count" class="font-semibold text-gray-800">0</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">参考点:</span>
+                        <span class="text-gray-600">Reference Point:</span>
                         <span id="ref-point-display" class="font-semibold text-gray-800">N/A</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">点击坐标:</span>
-                        <span id="click-coordinates-display" class="font-semibold text-blue-600">未点击</span>
+                        <span class="text-gray-600">Click Coordinates:</span>
+                        <span id="click-coordinates-display" class="font-semibold text-blue-600">Not clicked</span>
                     </div>
                 </div>
             </div>
@@ -166,10 +166,10 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 h-full">
                 <!-- Episode数据 -->
                 <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
-                    <h3 class="text-sm font-medium text-gray-700 mb-3">Episode数据</h3>
+                    <h3 class="text-sm font-medium text-gray-700 mb-3">Episode Data</h3>
                     <div id="episode-data-container"
                          class="text-xs space-y-2 max-h-32 overflow-y-auto custom-scrollbar">
-                        <div class="text-gray-500">请选择一个Episode查看详细数据</div>
+                        <div class="text-gray-500">Select an episode to view details</div>
                     </div>
                 </div>
 
@@ -177,13 +177,13 @@
                 <!-- 日志/操作历史 -->
                 <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
                     <div class="flex items-center justify-between mb-3">
-                        <h3 class="text-sm font-medium text-gray-700">操作日志</h3>
-                        <button id="clear-history-log-btn" class="text-xs text-gray-500 hover:text-gray-700">清除
+                        <h3 class="text-sm font-medium text-gray-700">Operation Log</h3>
+                        <button id="clear-history-log-btn" class="text-xs text-gray-500 hover:text-gray-700">Clear
                         </button>
                     </div>
                     <div id="history-log-container"
                          class="text-xs font-mono max-h-32 overflow-y-auto custom-scrollbar">
-                        <div class="text-gray-500">系统就绪，等待操作...</div>
+                        <div class="text-gray-500">System ready, waiting for actions...</div>
                     </div>
                 </div>
             </div>
@@ -196,7 +196,7 @@
      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
     <div class="bg-white rounded-lg p-6 flex items-center space-x-3">
         <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
-        <span class="text-gray-700">加载中...</span>
+        <span class="text-gray-700">Loading...</span>
     </div>
 </div>
 

--- a/tools/js/api-client.js
+++ b/tools/js/api-client.js
@@ -15,13 +15,13 @@ export function withErrorHandling(apiMethod) {
         try {
             return await apiMethod.apply(this, args);
         } catch (error) {
-            console.error(`API调用失败:`, error);
+            console.error(`API call failed:`, error);
 
             // 根据错误类型返回不同的错误信息
             if (error.message.includes('timeout') || error.message.includes('超时')) {
-                throw new Error('请求超时，请检查网络连接');
+                throw new Error('Request timed out, please check network connection');
             } else if (error.message.includes('Failed to fetch')) {
-                throw new Error('网络连接失败，请检查服务器状态');
+                throw new Error('Network connection failed, please check server status');
             } else {
                 throw error;
             }
@@ -100,7 +100,7 @@ export class ApiClient {
             return await response.json();
         } catch (error) {
             if (error.name === 'AbortError') {
-                throw new Error(`请求超时（${timeout / 1000}秒），请检查网络连接`);
+                throw new Error(`Request timed out (${timeout / 1000}s), please check network connection`);
             }
             throw error;
         }
@@ -115,7 +115,7 @@ export class ApiClient {
             await this.request('/training/health');
             return true;
         } catch (error) {
-            console.error('后端连接失败:', error);
+            console.error('Backend connection failed:', error);
             return false;
         }
     }

--- a/tools/js/canvas-renderer.js
+++ b/tools/js/canvas-renderer.js
@@ -191,7 +191,7 @@ export class CanvasRenderer {
         this.ctx.font = '16px sans-serif';
         this.ctx.textAlign = 'center';
         this.ctx.fillText(
-            '选择Mesh文件预览边界形状...',
+            'Select a mesh file to preview boundary...',
             displayWidth / 2,
             displayHeight / 2
         );
@@ -246,7 +246,7 @@ export class CanvasRenderer {
         this.ctx.font = 'bold 14px sans-serif';
         this.ctx.textAlign = 'center';
         this.ctx.fillText(
-            `${meshName} (${vertexCount} 个顶点)`,
+            `${meshName} (${vertexCount} vertices)`,
             displayWidth / 2,
             30
         );
@@ -328,7 +328,7 @@ export class CanvasRenderer {
                         allVertices.push(...adjacentVertices.filter(isValidCoordinate));
                     }
                 } catch (e) {
-                    console.warn('解析顶点数据失败:', vertexStr);
+                    console.warn('Failed to parse vertex data:', vertexStr);
                 }
             });
         }
@@ -391,7 +391,7 @@ export class CanvasRenderer {
                     });
                 }
             } catch (e) {
-                console.warn('渲染网格边失败:', vertexStr);
+                console.warn('Failed to render mesh edge:', vertexStr);
             }
         });
 
@@ -437,7 +437,7 @@ export class CanvasRenderer {
                     });
                 }
             } catch (e) {
-                console.warn('绘制网格顶点失败:', vertexStr);
+                console.warn('Failed to draw mesh vertex:', vertexStr);
             }
         });
     }

--- a/tools/js/history-manager.js
+++ b/tools/js/history-manager.js
@@ -70,13 +70,13 @@ export class HistoryManager {
             if (isConnected) {
                 await this.loadTrainingHistory();
             } else {
-                this.logMessage('无法连接到历史记录API服务器', LOG_TYPES.ERROR);
+                this.logMessage('Cannot connect to history API server', LOG_TYPES.ERROR);
             }
 
-            this.logMessage('历史记录查看器初始化完成', LOG_TYPES.INFO);
+            this.logMessage('History viewer initialized', LOG_TYPES.INFO);
         } catch (error) {
-            console.error('初始化失败:', error);
-            this.showError('系统初始化失败: ' + error.message);
+            console.error('Initialization failed:', error);
+            this.showError('System initialization failed: ' + error.message);
         }
     }
 
@@ -88,7 +88,7 @@ export class HistoryManager {
         if (canvas) {
             this.canvasRenderer = new CanvasRenderer(canvas);
         } else {
-            console.error('未找到Canvas元素');
+            console.error('Canvas element not found');
         }
     }
 
@@ -164,14 +164,14 @@ export class HistoryManager {
         try {
             const response = await this.apiClient.checkHistoryHealth();
             if (response.success && response.status === 'healthy') {
-                this.logMessage('历史记录API连接正常', LOG_TYPES.SUCCESS);
+                this.logMessage('History API connection successful', LOG_TYPES.SUCCESS);
                 return true;
             } else {
-                this.logMessage('历史记录API状态异常: ' + (response.error || '未知错误'), LOG_TYPES.WARNING);
+                this.logMessage('History API status abnormal: ' + (response.error || 'Unknown error'), LOG_TYPES.WARNING);
                 return false;
             }
         } catch (error) {
-            this.logMessage('历史记录API连接失败: ' + error.message, LOG_TYPES.ERROR);
+            this.logMessage('History API connection failed: ' + error.message, LOG_TYPES.ERROR);
             return false;
         }
     }
@@ -181,7 +181,7 @@ export class HistoryManager {
      */
     async loadTrainingHistory() {
         if (this.isLoadingHistory) {
-            this.logMessage('正在加载训练历史记录，请稍候...', LOG_TYPES.WARNING);
+            this.logMessage('Loading training history, please wait...', LOG_TYPES.WARNING);
             return;
         }
         try {
@@ -193,16 +193,16 @@ export class HistoryManager {
             if (response.success && response.training_ids) {
                 this.trainingList = response.training_ids;
                 this.updateTrainingList();
-                this.logMessage(`成功加载 ${response.count} 个训练历史记录`, LOG_TYPES.SUCCESS);
+                this.logMessage(`Loaded ${response.count} training history entries`, LOG_TYPES.SUCCESS);
             } else {
-                this.logMessage('未找到训练历史记录: ' + (response.error || '未知错误'), LOG_TYPES.WARNING);
+                this.logMessage('No training history found: ' + (response.error || 'Unknown error'), LOG_TYPES.WARNING);
                 this.trainingList = [];
                 this.updateTrainingList();
             }
 
         } catch (error) {
-            console.error('加载训练历史失败:', error);
-            this.showError('加载训练历史失败: ' + error.message);
+            console.error('Failed to load training history:', error);
+            this.showError('Failed to load training history: ' + error.message);
         } finally {
             this.showLoading(false);
             this.isLoadingHistory = false;
@@ -214,10 +214,10 @@ export class HistoryManager {
      */
     async refreshTrainingHistory() {
         if (this.isLoadingHistory) {
-            this.logMessage('正在刷新中，请稍候...', LOG_TYPES.WARNING);
+            this.logMessage('Refreshing, please wait...', LOG_TYPES.WARNING);
             return;
         }
-        this.logMessage('正在刷新训练历史记录...', LOG_TYPES.INFO);
+        this.logMessage('Refreshing training history...', LOG_TYPES.INFO);
         await this.loadTrainingHistory();
     }
 
@@ -230,12 +230,12 @@ export class HistoryManager {
             const response = await this.apiClient.checkHistoryHealth();
 
             if (response.success && response.status === 'healthy') {
-                this.logMessage(`服务健康检查通过 - 可用训练: ${response.available_trainings}`, LOG_TYPES.SUCCESS);
+                this.logMessage(`Health check passed - available trainings: ${response.available_trainings}`, LOG_TYPES.SUCCESS);
                 if (response.current_focus) {
-                    this.logMessage(`当前聚焦: ${response.current_focus}`, LOG_TYPES.INFO);
+                    this.logMessage(`Current focus: ${response.current_focus}`, LOG_TYPES.INFO);
                 }
             } else {
-                this.logMessage(`服务状态异常: ${response.error || '未知错误'}`, LOG_TYPES.ERROR);
+                this.logMessage(`Service status abnormal: ${response.error || 'Unknown error'}`, LOG_TYPES.ERROR);
             }
         } catch (error) {
             this.logMessage(`健康检查失败: ${error.message}`, LOG_TYPES.ERROR);
@@ -327,14 +327,14 @@ export class HistoryManager {
                 // 默认加载最佳Episode
                 await this.loadEpisode(this.currentTrainingInfo.best_episode);
 
-                this.logMessage(`训练加载成功: ${response.detail_length} episodes`, LOG_TYPES.SUCCESS);
+                this.logMessage(`Training loaded successfully: ${response.detail_length} episodes`, LOG_TYPES.SUCCESS);
             } else {
-                this.showError('加载训练信息失败: ' + response.error);
+                this.showError('Failed to load training info: ' + response.error);
             }
 
         } catch (error) {
-            console.error('选择训练失败:', error);
-            this.showError('选择训练失败: ' + error.message);
+            console.error('Failed to select training:', error);
+            this.showError('Failed to select training: ' + error.message);
         } finally {
             this.showLoading(false);
         }
@@ -388,12 +388,12 @@ export class HistoryManager {
      */
     async loadEpisode(episodeIndex) {
         if (!this.currentTrainingId || !this.currentTrainingInfo) {
-            this.showError('请先选择一个训练会话');
+            this.showError('Please select a training session first');
             return;
         }
 
         if (episodeIndex < 0 || episodeIndex >= this.currentTrainingInfo.detail_length) {
-            this.showError(`Episode索引超出范围: ${episodeIndex}`);
+            this.showError(`Episode index out of range: ${episodeIndex}`);
             return;
         }
 
@@ -418,14 +418,14 @@ export class HistoryManager {
                     episodeInput.value = episodeIndex;
                 }
 
-                this.logMessage(`Episode ${episodeIndex} 加载成功`, LOG_TYPES.SUCCESS);
+                this.logMessage(`Episode ${episodeIndex} loaded successfully`, LOG_TYPES.SUCCESS);
             } else {
-                this.showError('加载Episode失败: ' + response.error);
+                this.showError('Failed to load episode: ' + response.error);
             }
 
         } catch (error) {
-            console.error('加载Episode失败:', error);
-            this.showError('加载Episode失败: ' + error.message);
+            console.error('Failed to load episode:', error);
+            this.showError('Failed to load episode: ' + error.message);
         } finally {
             this.showLoading(false);
         }
@@ -443,7 +443,7 @@ export class HistoryManager {
         this.updateElement('actual-episode-number-display', episode_number || 'N/A');
         this.updateElement('episode-reward-display', formatNumber(reward));
         this.updateElement('episode-length-display', length);
-        this.updateElement('episode-status-display', is_completed ? '完成' : '未完成');
+        this.updateElement('episode-status-display', is_completed ? 'Completed' : 'Incomplete');
 
         // 显示元信息
         const metaInfo = this.elements['episode-meta-info'];
@@ -499,9 +499,9 @@ export class HistoryManager {
                     <span class="episode-data-value">${length}</span>
                 </div>
                 <div class="episode-data-item">
-                    <span class="episode-data-key">状态:</span>
+                    <span class="episode-data-key">Status:</span>
                     <span class="episode-data-value ${is_completed ? 'text-green-600' : 'text-orange-600'}">
-                        ${is_completed ? '完成' : '未完成'}
+                        ${is_completed ? 'Completed' : 'Incomplete'}
                     </span>
                 </div>
             `;
@@ -531,7 +531,7 @@ export class HistoryManager {
 
         const episodeIndex = parseInt(episodeInput.value);
         if (isNaN(episodeIndex)) {
-            this.showError('请输入有效的Episode索引');
+            this.showError('Please enter a valid episode index');
             return;
         }
 
@@ -567,7 +567,7 @@ export class HistoryManager {
 
         const transform = this.canvasRenderer.getCurrentTransform();
         if (!transform) {
-            this.updateElement('click-coordinates-display', '无变换数据');
+            this.updateElement('click-coordinates-display', 'No transform data');
             return;
         }
 
@@ -642,7 +642,7 @@ export class HistoryManager {
     clearLogs() {
         const container = this.elements['history-log-container'];
         if (container) {
-            container.innerHTML = '<div class="text-gray-500">日志已清除</div>';
+            container.innerHTML = '<div class="text-gray-500">Logs cleared</div>';
         }
     }
 
@@ -653,7 +653,7 @@ export class HistoryManager {
         if (this.canvasRenderer) {
             this.canvasRenderer.onResize();
         }
-        this.logMessage('窗口大小已调整', LOG_TYPES.INFO);
+        this.logMessage('Window resized', LOG_TYPES.INFO);
     }
 
     /**
@@ -677,6 +677,6 @@ export class HistoryManager {
         this.currentEpisodeIndex = null;
         this.currentEpisodeData = null;
 
-        console.log('HistoryManager已销毁');
+        console.log('HistoryManager destroyed');
     }
 }

--- a/tools/js/index.js
+++ b/tools/js/index.js
@@ -23,11 +23,11 @@ export const VERSION = '1.0.0';
 
 // 模块信息
 export const MODULES = {
-    utils: '工具函数模块',
-    apiClient: 'API客户端模块',
-    canvasRenderer: 'Canvas渲染模块',
-    uiController: 'UI控制器模块',
-    trainingManager: '训练管理器主模块'
+    utils: 'Utility module',
+    apiClient: 'API client module',
+    canvasRenderer: 'Canvas renderer module',
+    uiController: 'UI controller module',
+    trainingManager: 'Training manager module'
 };
 
 // 检查所有模块是否正确加载
@@ -40,6 +40,6 @@ export function checkModules() {
         trainingManager: typeof TrainingManager !== 'undefined'
     };
 
-    console.log('模块加载状态:', results);
+    console.log('Module load status:', results);
     return results;
 }

--- a/tools/js/training-manager.js
+++ b/tools/js/training-manager.js
@@ -40,14 +40,14 @@ export class TrainingManager {
                 await this.loadMeshList();
                 await this.loadCheckpointList(); // 新增：加载checkpoint列表
             } else {
-                this.uiController.logMessage('无法连接到后端服务器，请确保Flask应用正在运行在 http://localhost:5000', LOG_TYPES.ERROR);
+                this.uiController.logMessage('Cannot connect to backend server. Ensure the Flask app is running at http://localhost:5000', LOG_TYPES.ERROR);
             }
 
             this.uiController.updateButtonStates(false);
-            this.uiController.logMessage('系统初始化完成', LOG_TYPES.INFO);
+            this.uiController.logMessage('System initialization completed', LOG_TYPES.INFO);
         } catch (error) {
-            console.error('初始化失败:', error);
-            this.uiController.showError('系统初始化失败: ' + error.message);
+            console.error('Initialization failed:', error);
+            this.uiController.showError('System initialization failed: ' + error.message);
         }
     }
 
@@ -59,7 +59,7 @@ export class TrainingManager {
         if (canvas) {
             this.canvasRenderer = new CanvasRenderer(canvas);
         } else {
-            console.error('未找到Canvas元素');
+            console.error('Canvas element not found');
         }
     }
 
@@ -124,11 +124,11 @@ export class TrainingManager {
         try {
             const connected = await this.apiClient.checkConnection();
             if (connected) {
-                this.uiController.logMessage('后端连接正常', LOG_TYPES.SUCCESS);
+                this.uiController.logMessage('Backend connection successful', LOG_TYPES.SUCCESS);
             }
             return connected;
         } catch (error) {
-            this.uiController.logMessage('后端连接失败: ' + error.message, LOG_TYPES.ERROR);
+            this.uiController.logMessage('Backend connection failed: ' + error.message, LOG_TYPES.ERROR);
             return false;
         }
     }
@@ -145,14 +145,14 @@ export class TrainingManager {
             this.uiController.populateMeshList(data.meshes || []);
 
             if (data.meshes && data.meshes.length > 0) {
-                this.uiController.logMessage(`成功加载 ${data.meshes.length} 个Mesh文件`, LOG_TYPES.SUCCESS);
+                this.uiController.logMessage(`Loaded ${data.meshes.length} mesh files`, LOG_TYPES.SUCCESS);
             } else {
-                this.uiController.logMessage('未找到可用的Mesh文件', LOG_TYPES.WARNING);
+                this.uiController.logMessage('No mesh files found', LOG_TYPES.WARNING);
             }
 
         } catch (error) {
-            console.error('加载Mesh列表失败:', error);
-            this.uiController.showError('加载Mesh列表失败: ' + error.message);
+            console.error('Failed to load mesh list:', error);
+            this.uiController.showError('Failed to load mesh list: ' + error.message);
         } finally {
             this.uiController.showLoading(false);
         }
@@ -168,14 +168,14 @@ export class TrainingManager {
             this.uiController.populateCheckpointList(data.checkpoints || []);
 
             if (data.checkpoints && data.checkpoints.length > 0) {
-                this.uiController.logMessage(`成功加载 ${data.checkpoints.length} 个Checkpoint文件`, LOG_TYPES.SUCCESS);
+                this.uiController.logMessage(`Loaded ${data.checkpoints.length} checkpoint files`, LOG_TYPES.SUCCESS);
             } else {
-                this.uiController.logMessage('未找到可用的Checkpoint文件', LOG_TYPES.INFO);
+                this.uiController.logMessage('No checkpoint files found', LOG_TYPES.INFO);
             }
 
         } catch (error) {
-            console.error('加载Checkpoint列表失败:', error);
-            this.uiController.logMessage('加载Checkpoint列表失败: ' + error.message, LOG_TYPES.WARNING);
+            console.error('Failed to load checkpoint list:', error);
+            this.uiController.logMessage('Failed to load checkpoint list: ' + error.message, LOG_TYPES.WARNING);
         }
     }
 
@@ -204,7 +204,7 @@ export class TrainingManager {
 
             // 更新UI信息
             this.uiController.showMeshInfo(info);
-            this.uiController.logMessage(`选择了Mesh: ${meshName}`, LOG_TYPES.INFO);
+            this.uiController.logMessage(`Selected mesh: ${meshName}`, LOG_TYPES.INFO);
 
             // 在canvas中渲染边界预览
             if (this.canvasRenderer && boundaryData.success) {
@@ -213,19 +213,19 @@ export class TrainingManager {
                     meshName
                 );
                 this.uiController.logMessage(
-                    `已加载边界预览: ${boundaryData.vertex_count} 个顶点`,
+                    `Loaded boundary preview: ${boundaryData.vertex_count} vertices`,
                     LOG_TYPES.SUCCESS
                 );
             } else if (!boundaryData.success) {
                 this.uiController.logMessage(
-                    `无法加载边界数据: ${boundaryData.error}`,
+                    `Failed to load boundary data: ${boundaryData.error}`,
                     LOG_TYPES.WARNING
                 );
             }
 
         } catch (error) {
-            console.error('获取Mesh信息失败:', error);
-            this.uiController.showError('获取Mesh信息失败: ' + error.message);
+            console.error('Failed to get mesh info:', error);
+            this.uiController.showError('Failed to get mesh info: ' + error.message);
             this.uiController.hideMeshInfo();
 
             // 清空canvas
@@ -245,9 +245,9 @@ export class TrainingManager {
         this.uiController.showCheckpointSelection(useCheckpoint);
 
         if (useCheckpoint) {
-            this.uiController.logMessage('已启用Checkpoint模式', LOG_TYPES.INFO);
+            this.uiController.logMessage('Checkpoint mode enabled', LOG_TYPES.INFO);
         } else {
-            this.uiController.logMessage('已禁用Checkpoint模式', LOG_TYPES.INFO);
+            this.uiController.logMessage('Checkpoint mode disabled', LOG_TYPES.INFO);
             this.uiController.hideCheckpointInfo();
         }
     }
@@ -270,14 +270,14 @@ export class TrainingManager {
 
             if (response.success && response.checkpoint_info) {
                 this.uiController.showCheckpointInfo(response.checkpoint_info);
-                this.uiController.logMessage(`选择了Checkpoint: ${checkpointName}`, LOG_TYPES.INFO);
+                this.uiController.logMessage(`Selected checkpoint: ${checkpointName}`, LOG_TYPES.INFO);
             } else {
-                this.uiController.showError('获取Checkpoint信息失败');
+                this.uiController.showError('Failed to get checkpoint info');
             }
 
         } catch (error) {
-            console.error('获取Checkpoint信息失败:', error);
-            this.uiController.showError('获取Checkpoint信息失败: ' + error.message);
+            console.error('Failed to get checkpoint info:', error);
+            this.uiController.showError('Failed to get checkpoint info: ' + error.message);
             this.uiController.hideCheckpointInfo();
         } finally {
             this.uiController.showLoading(false);
@@ -310,7 +310,7 @@ export class TrainingManager {
 
         // 记录到日志
         const coordText = `(${worldCoords[0].toFixed(3)}, ${worldCoords[1].toFixed(3)})`;
-        this.uiController.logMessage(`点击坐标: ${coordText}`, LOG_TYPES.INFO);
+        this.uiController.logMessage(`Click coordinates: ${coordText}`, LOG_TYPES.INFO);
     }
 
     /**
@@ -337,9 +337,9 @@ export class TrainingManager {
 
             const result = await this.apiClient.startTraining(config);
 
-            let successMessage = '训练已启动: ' + result.message;
+            let successMessage = 'Training started: ' + result.message;
             if (result.from_checkpoint && result.checkpoint_name) {
-                successMessage += ` (继续训练自checkpoint: ${result.checkpoint_name})`;
+                successMessage += ` (continued from checkpoint: ${result.checkpoint_name})`;
             }
 
             this.uiController.logMessage(successMessage, LOG_TYPES.SUCCESS);
@@ -352,8 +352,8 @@ export class TrainingManager {
             this.scheduleImmediateUpdate();
 
         } catch (error) {
-            console.error('启动训练失败:', error);
-            this.uiController.showError('启动训练失败: ' + error.message);
+            console.error('Failed to start training:', error);
+            this.uiController.showError('Failed to start training: ' + error.message);
         } finally {
             this.uiController.showLoading(false);
         }
@@ -375,7 +375,7 @@ export class TrainingManager {
             setTimeout(async () => {
                 if (this.isTraining) {
                     await this.updateTrainingStatus();
-                    this.uiController.logMessage(`获取训练状态更新 #${index + 1}`, LOG_TYPES.INFO);
+                    this.uiController.logMessage(`Training status update #${index + 1}`, LOG_TYPES.INFO);
                 }
             }, delay);
         });
@@ -400,11 +400,11 @@ export class TrainingManager {
             this.uiController.showLoading(true);
 
             const result = await this.apiClient.stopTraining();
-            this.uiController.logMessage('训练停止请求已发送: ' + result.message, LOG_TYPES.INFO);
+            this.uiController.logMessage('Training stop request sent: ' + result.message, LOG_TYPES.INFO);
 
         } catch (error) {
-            console.error('停止训练失败:', error);
-            this.uiController.showError('停止训练失败: ' + error.message);
+            console.error('Failed to stop training:', error);
+            this.uiController.showError('Failed to stop training: ' + error.message);
         } finally {
             this.uiController.showLoading(false);
         }
@@ -458,8 +458,8 @@ export class TrainingManager {
             const status = await this.apiClient.getTrainingStatus();
             this.handleStatusUpdate(status);
         } catch (error) {
-            console.error('获取训练状态失败:', error);
-            this.uiController.logMessage('获取训练状态失败: ' + error.message, LOG_TYPES.ERROR);
+            console.error('Failed to get training status:', error);
+            this.uiController.logMessage('Failed to get training status: ' + error.message, LOG_TYPES.ERROR);
         }
     }
 
@@ -527,7 +527,7 @@ export class TrainingManager {
         if (this.canvasRenderer) {
             this.canvasRenderer.onResize();
         }
-        this.uiController.logMessage('窗口大小已调整', LOG_TYPES.INFO);
+        this.uiController.logMessage('Window resized', LOG_TYPES.INFO);
     }
 
     /**
@@ -562,6 +562,6 @@ export class TrainingManager {
 
         this.uiController.reset();
 
-        console.log('TrainingManager已销毁');
+        console.log('TrainingManager destroyed');
     }
 }

--- a/tools/js/ui-controller.js
+++ b/tools/js/ui-controller.js
@@ -54,12 +54,12 @@ export class UIController {
         indicator.className = 'w-2 h-2 rounded-full mr-2';
 
         const statusConfig = {
-            [STATUS.RUNNING]: {class: 'status-running', text: '训练中'},
-            [STATUS.STOPPED]: {class: 'status-stopped', text: '已停止'},
-            [STATUS.COMPLETED]: {class: 'status-success', text: '已完成'},
-            [STATUS.STOPPING]: {class: 'status-loading', text: '停止中'},
-            [STATUS.ERROR]: {class: 'status-stopped', text: '出错'},
-            [STATUS.IDLE]: {class: 'status-idle', text: '未启动'}
+            [STATUS.RUNNING]: {class: 'status-running', text: 'Running'},
+            [STATUS.STOPPED]: {class: 'status-stopped', text: 'Stopped'},
+            [STATUS.COMPLETED]: {class: 'status-success', text: 'Completed'},
+            [STATUS.STOPPING]: {class: 'status-loading', text: 'Stopping'},
+            [STATUS.ERROR]: {class: 'status-stopped', text: 'Error'},
+            [STATUS.IDLE]: {class: 'status-idle', text: 'Idle'}
         };
 
         const config = statusConfig[status] || statusConfig[STATUS.IDLE];
@@ -202,7 +202,7 @@ export class UIController {
         if (!select) return;
 
         // 清空现有选项
-        select.innerHTML = '<option value="">选择一个Mesh</option>';
+        select.innerHTML = '<option value="">Select a Mesh</option>';
 
         if (Array.isArray(meshes) && meshes.length > 0) {
             meshes.forEach(mesh => {
@@ -214,7 +214,7 @@ export class UIController {
         } else {
             const option = document.createElement('option');
             option.value = '';
-            option.textContent = '未找到可用的Mesh文件';
+            option.textContent = 'No mesh files found';
             select.appendChild(option);
         }
     }
@@ -230,7 +230,7 @@ export class UIController {
         this.checkpoints = checkpoints || [];
 
         // 清空现有选项
-        select.innerHTML = '<option value="">选择一个Checkpoint</option>';
+        select.innerHTML = '<option value="">Select a Checkpoint</option>';
 
         if (Array.isArray(checkpoints) && checkpoints.length > 0) {
             checkpoints.forEach(checkpoint => {
@@ -244,7 +244,7 @@ export class UIController {
                 // 如果checkpoint无效，禁用该选项
                 if (!checkpoint.is_valid) {
                     option.disabled = true;
-                    option.textContent += ' [无效]';
+                    option.textContent += ' [Invalid]';
                 }
 
                 select.appendChild(option);
@@ -252,7 +252,7 @@ export class UIController {
         } else {
             const option = document.createElement('option');
             option.value = '';
-            option.textContent = '未找到可用的Checkpoint文件';
+            option.textContent = 'No checkpoint files found';
             select.appendChild(option);
         }
     }
@@ -300,12 +300,12 @@ export class UIController {
         if (detailsDiv) {
             detailsDiv.innerHTML = `
                 <div class="text-xs text-gray-600 space-y-1">
-                    <div>训练步数: ${info.training_timesteps.toLocaleString()}</div>
-                    <div>学习率: ${info.learning_rate}</div>
-                    <div>文件大小: ${info.file_size_mb} MB</div>
-                    <div>修改时间: ${info.modified_datetime}</div>
-                    <div>有效性: ${info.is_valid ? '✓ 有效' : '✗ 无效'}</div>
-                    ${info.has_replay_buffer ? '<div>包含经验回放缓冲区</div>' : ''}
+                    <div>Training steps: ${info.training_timesteps.toLocaleString()}</div>
+                    <div>Learning rate: ${info.learning_rate}</div>
+                    <div>File size: ${info.file_size_mb} MB</div>
+                    <div>Modified: ${info.modified_datetime}</div>
+                    <div>Valid: ${info.is_valid ? '✓ Valid' : '✗ Invalid'}</div>
+                    ${info.has_replay_buffer ? '<div>Contains replay buffer</div>' : ''}
                 </div>
             `;
         }
@@ -370,7 +370,7 @@ export class UIController {
     clearLogs() {
         const container = this.elements['log-container'];
         if (container) {
-            container.innerHTML = '<div class="text-gray-500">日志已清除</div>';
+            container.innerHTML = '<div class="text-gray-500">Logs cleared</div>';
         }
     }
 
@@ -380,7 +380,7 @@ export class UIController {
      */
     updateClickCoordinates(coords) {
         if (!coords || !Array.isArray(coords) || coords.length !== 2) {
-            this.updateElement('click-coordinates', '无变换数据');
+            this.updateElement('click-coordinates', 'No transform data');
             return;
         }
 
@@ -464,7 +464,7 @@ export class UIController {
         if (!config.mesh_name) {
             return {
                 valid: false,
-                message: '请先选择一个Mesh文件'
+                message: 'Please select a mesh file first'
             };
         }
 
@@ -476,7 +476,7 @@ export class UIController {
             if (!config.checkpoint_name) {
                 return {
                     valid: false,
-                    message: '启用checkpoint模式时必须选择一个checkpoint'
+                    message: 'A checkpoint must be selected when checkpoint mode is enabled'
                 };
             }
 
@@ -485,7 +485,7 @@ export class UIController {
             if (!selectedCheckpoint || !selectedCheckpoint.is_valid) {
                 return {
                     valid: false,
-                    message: '选择的checkpoint无效'
+                    message: 'Selected checkpoint is invalid'
                 };
             }
         }
@@ -494,21 +494,21 @@ export class UIController {
         if (!config.max_timesteps) {
             return {
                 valid: false,
-                message: '请指定最大训练步数'
+                message: 'Please specify max training steps'
             };
         }
 
         if (config.max_timesteps && config.max_timesteps < 1000) {
             return {
                 valid: false,
-                message: '最大训练步数应至少为1000'
+                message: 'Max training steps should be at least 1000'
             };
         }
 
         if (config.max_steps && config.max_steps < 1) {
             return {
                 valid: false,
-                message: '每Episode最大步数必须大于0'
+                message: 'Max steps per episode must be greater than 0'
             };
         }
 

--- a/tools/js/utils.js
+++ b/tools/js/utils.js
@@ -152,7 +152,7 @@ export function parseBackendData(data) {
         try {
             return JSON.parse(data);
         } catch (e) {
-            console.error('解析数据失败:', e);
+            console.error('Failed to parse data:', e);
             return null;
         }
     }
@@ -213,7 +213,7 @@ export function safeGetElement(id) {
     try {
         return document.getElementById(id);
     } catch (error) {
-        console.warn(`无法获取元素 ${id}:`, error);
+        console.warn(`Failed to get element ${id}:`, error);
         return null;
     }
 }

--- a/tools/train.html
+++ b/tools/train.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>强化学习网格生成训练管理</title>
+    <title>RL Mesh Generation Training Manager</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="css/train.css">
     <script>
@@ -29,8 +29,8 @@
     <div class="left-panel shadow-lg">
         <!-- 头部 -->
         <div class="p-6 border-b border-gray-200">
-            <h1 class="text-2xl font-bold text-gray-800">训练管理</h1>
-            <p class="text-sm text-gray-600 mt-1">强化学习网格生成系统</p>
+            <h1 class="text-2xl font-bold text-gray-800">Training Manager</h1>
+            <p class="text-sm text-gray-600 mt-1">Reinforcement Learning Mesh Generation</p>
         </div>
 
         <!-- 控制区域 -->
@@ -38,10 +38,10 @@
             <!-- 状态指示器 -->
             <div class="mb-6">
                 <div class="flex items-center justify-between mb-2">
-                    <span class="text-sm font-medium text-gray-700">训练状态</span>
+                    <span class="text-sm font-medium text-gray-700">Training Status</span>
                     <div id="status-indicator" class="flex items-center">
                         <div class="w-2 h-2 bg-gray-400 rounded-full mr-2"></div>
-                        <span id="status-text" class="text-sm text-gray-600">未启动</span>
+                        <span id="status-text" class="text-sm text-gray-600">Idle</span>
                     </div>
                 </div>
             </div>
@@ -52,16 +52,16 @@
                     <input id="checkpoint-mode" type="checkbox"
                            class="h-4 w-4 text-primary focus:ring-primary border-gray-300 rounded">
                     <label for="checkpoint-mode" class="ml-2 text-sm font-medium text-gray-700">
-                        从Checkpoint继续训练
+                        Continue from Checkpoint
                     </label>
                 </div>
 
                 <!-- Checkpoint选择 -->
                 <div id="checkpoint-selection" style="display: none;">
-                    <label class="block text-sm font-medium text-gray-700 mb-2">选择Checkpoint</label>
+                    <label class="block text-sm font-medium text-gray-700 mb-2">Select Checkpoint</label>
                     <select id="checkpoint-select"
                             class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                        <option value="">加载中...</option>
+                        <option value="">Loading...</option>
                     </select>
 
                     <!-- Checkpoint信息显示 -->
@@ -75,47 +75,47 @@
 
             <!-- Mesh选择 -->
             <div class="mb-6">
-                <label class="block text-sm font-medium text-gray-700 mb-2">选择初始Mesh</label>
+                <label class="block text-sm font-medium text-gray-700 mb-2">Select Initial Mesh</label>
                 <select id="mesh-select"
                         class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <option value="">加载中...</option>
+                    <option value="">Loading...</option>
                 </select>
                 <div id="mesh-info" class="mt-2 text-xs text-gray-500 hidden">
-                    <div>顶点数: <span id="mesh-vertices">0</span></div>
-                    <div>文件大小: <span id="mesh-size">0</span> bytes</div>
+                    <div>Vertices: <span id="mesh-vertices">0</span></div>
+                    <div>File size: <span id="mesh-size">0</span> bytes</div>
                 </div>
             </div>
 
             <!-- 训练参数 -->
             <div class="mb-6">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">训练参数</h3>
+                <h3 class="text-sm font-medium text-gray-700 mb-3">Training Parameters</h3>
 
                 <div class="mb-4">
-                    <label class="block text-xs text-gray-600 mb-1">最大训练步数 (Timesteps)</label>
+                    <label class="block text-xs text-gray-600 mb-1">Max Training Steps (Timesteps)</label>
                     <input id="max-timesteps" type="number" value="1000000" min="1000"
                            class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <p class="text-xs text-gray-500 mt-1">控制参数：总的训练步数</p>
+                    <p class="text-xs text-gray-500 mt-1">Control parameter: total training steps</p>
                 </div>
 
                 <div class="mb-4">
-                    <label class="block text-xs text-gray-600 mb-1">每Episode最大步数</label>
+                    <label class="block text-xs text-gray-600 mb-1">Max Steps per Episode</label>
                     <input id="max-steps" type="number" value="1000" min="1"
                            class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <p class="text-xs text-gray-500 mt-1">单个episode的步数限制</p>
+                    <p class="text-xs text-gray-500 mt-1">Step limit for a single episode</p>
                 </div>
 
                 <div class="mb-4">
-                    <label class="block text-xs text-gray-600 mb-1">更新间隔 (秒)</label>
+                    <label class="block text-xs text-gray-600 mb-1">Update Interval (s)</label>
                     <input id="update-interval" type="number" value="10" min="1"
                            class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <p class="text-xs text-gray-500 mt-1">前端状态更新频率</p>
+                    <p class="text-xs text-gray-500 mt-1">Frontend status update frequency</p>
                 </div>
 
                 <div class="mb-4">
-                    <label class="block text-xs text-gray-600 mb-1">训练描述 (可选)</label>
-                    <input id="description" type="text" placeholder="例如：测试新的奖励函数"
+                    <label class="block text-xs text-gray-600 mb-1">Training Description (optional)</label>
+                    <input id="description" type="text" placeholder="e.g., test new reward function"
                            class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary">
-                    <p class="text-xs text-gray-500 mt-1">描述本次训练的目的或特点</p>
+                    <p class="text-xs text-gray-500 mt-1">Describe this training purpose or features</p>
                 </div>
             </div>
 
@@ -123,37 +123,37 @@
             <div class="space-y-3">
                 <button id="start-btn"
                         class="w-full bg-primary hover:bg-blue-600 text-white font-medium py-3 px-4 rounded-lg transition-colors duration-200">
-                    开始训练
+                    Start Training
                 </button>
                 <button id="stop-btn"
                         class="w-full bg-danger hover:bg-red-600 text-white font-medium py-3 px-4 rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                         disabled>
-                    停止训练
+                    Stop Training
                 </button>
                 <button id="refresh-btn"
                         class="w-full bg-gray-500 hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200">
-                    刷新状态
+                    Refresh Status
                 </button>
             </div>
 
             <!-- 训练统计 -->
             <div class="mt-6 pt-6 border-t border-gray-200">
-                <h3 class="text-sm font-medium text-gray-700 mb-3">训练统计</h3>
+                <h3 class="text-sm font-medium text-gray-700 mb-3">Training Stats</h3>
                 <div class="space-y-2 text-xs">
                     <div class="flex justify-between">
-                        <span class="text-gray-600">当前Episode:</span>
+                        <span class="text-gray-600">Current Episode:</span>
                         <span id="current-episode" class="font-medium">0</span>
                     </div>
                     <div class="flex justify-between">
-                        <span class="text-gray-600">总步数 (Timesteps):</span>
+                        <span class="text-gray-600">Total Steps (Timesteps):</span>
                         <span id="total-steps" class="font-medium">0</span>
                     </div>
                     <div class="flex justify-between">
-                        <span class="text-gray-600">平均奖励:</span>
+                        <span class="text-gray-600">Average Reward:</span>
                         <span id="avg-reward" class="font-medium">0.000</span>
                     </div>
                     <div class="flex justify-between">
-                        <span class="text-gray-600">缓冲区大小:</span>
+                        <span class="text-gray-600">Buffer Size:</span>
                         <span id="buffer-size" class="font-medium">0</span>
                     </div>
                 </div>
@@ -167,27 +167,27 @@
         <div class="top-info-bar shadow-sm">
             <div class="flex items-center justify-between flex-wrap gap-4">
                 <div>
-                    <h2 class="text-lg font-semibold text-gray-800">网格可视化</h2>
+                    <h2 class="text-lg font-semibold text-gray-800">Mesh Visualization</h2>
                     <p class="text-sm text-gray-600">Episode <span id="display-episode">0</span> -
-                        边界顶点: <span id="boundary-vertices">0</span> -
-                        总步数: <span id="display-total-steps">0</span></p>
+                        Boundary Vertices: <span id="boundary-vertices">0</span> -
+                        Total Steps: <span id="display-total-steps">0</span></p>
                 </div>
                 <div class="flex items-center space-x-4 flex-wrap">
                     <div class="text-sm">
-                        <span class="text-gray-600">Episode长度:</span>
+                        <span class="text-gray-600">Episode Length:</span>
                         <span id="episode-length" class="font-semibold text-gray-800">0</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">Episode奖励:</span>
+                        <span class="text-gray-600">Episode Reward:</span>
                         <span id="episode-reward" class="font-semibold text-gray-800">0.000</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">参考点:</span>
+                        <span class="text-gray-600">Reference Point:</span>
                         <span id="ref-point" class="font-semibold text-gray-800">N/A</span>
                     </div>
                     <div class="text-sm">
-                        <span class="text-gray-600">点击坐标:</span>
-                        <span id="click-coordinates" class="font-semibold text-blue-600">未点击</span>
+                        <span class="text-gray-600">Click Coordinates:</span>
+                        <span id="click-coordinates" class="font-semibold text-blue-600">Not clicked</span>
                     </div>
                 </div>
             </div>
@@ -205,12 +205,12 @@
         <!-- 底部日志区域 - 添加响应式类 -->
         <div class="bottom-log-area">
             <div class="flex items-center justify-between mb-2">
-                <h3 class="text-sm font-medium text-gray-700">训练日志</h3>
-                <button id="clear-log-btn" class="text-xs text-gray-500 hover:text-gray-700">清除</button>
+                <h3 class="text-sm font-medium text-gray-700">Training Log</h3>
+                <button id="clear-log-btn" class="text-xs text-gray-500 hover:text-gray-700">Clear</button>
             </div>
             <div id="log-container"
                  class="h-20 overflow-y-auto bg-gray-50 rounded px-3 py-2 text-xs font-mono custom-scrollbar">
-                <div class="text-gray-500">等待训练开始...</div>
+                <div class="text-gray-500">Waiting for training to start...</div>
             </div>
         </div>
     </div>
@@ -220,7 +220,7 @@
 <div id="loading-overlay" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
     <div class="bg-white rounded-lg p-6 flex items-center space-x-3">
         <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary"></div>
-        <span class="text-gray-700">处理中...</span>
+        <span class="text-gray-700">Processing...</span>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- localize canvas, history, and train HTML files to English
- translate user-facing JS messages across tools
- update default texts in utilities and module index

## Testing
- `grep -nP "[\x{4e00}-\x{9fff}]" tools/js/training-manager.js` *(returns nothing except comments)*

------
https://chatgpt.com/codex/tasks/task_e_68788bc1d258832a81bb2caaad921d3b