### PR TITLE
Fix history requests and handle timeout

### DIFF
--- a/tools/js/history-api-client.js
+++ b/tools/js/history-api-client.js
@@ -17,7 +17,7 @@ export class HistoryApiClient extends ApiClient {
      * @returns {Promise<Object>} 训练历史列表响应
      */
     async getTrainingHistoryList() {
-        try {
+        const fetchList = async () => {
             const response = await this.request(`${this.historyBasePath}/list`);
             return {
                 success: response.success || false,
@@ -25,7 +25,25 @@ export class HistoryApiClient extends ApiClient {
                 count: response.count || 0,
                 error: response.error || null
             };
+        };
+
+        try {
+            return await fetchList();
         } catch (error) {
+            if (error.message && error.message.toLowerCase().includes('timed out')) {
+                try {
+                    // Retry once if the first request timed out
+                    return await fetchList();
+                } catch (secondError) {
+                    return {
+                        success: false,
+                        training_ids: [],
+                        count: 0,
+                        error: secondError.message
+                    };
+                }
+            }
+
             return {
                 success: false,
                 training_ids: [],

--- a/tools/js/history-manager.js
+++ b/tools/js/history-manager.js
@@ -281,14 +281,14 @@ export class HistoryManager {
 
         container.innerHTML = itemsHTML;
 
-        // 绑定点击事件
-        container.addEventListener('click', (e) => {
+        // 绑定点击事件，确保不会重复绑定导致多次请求
+        container.onclick = (e) => {
             const trainingItem = e.target.closest('.training-item');
             if (trainingItem) {
                 const trainingId = trainingItem.dataset.trainingId;
                 this.selectTraining(trainingId);
             }
-        });
+        };
     }
 
     /**
@@ -303,8 +303,13 @@ export class HistoryManager {
      */
     async selectTraining(trainingId) {
         if (trainingId === this.currentTrainingId) return;
+        if (this.isLoadingTraining) {
+            this.logMessage('Training is loading, please wait...', LOG_TYPES.WARNING);
+            return;
+        }
 
         try {
+            this.isLoadingTraining = true;
             this.showLoading(true);
             this.logMessage(`正在加载训练: ${trainingId}`, LOG_TYPES.INFO);
 
@@ -337,6 +342,7 @@ export class HistoryManager {
             this.showError('Failed to select training: ' + error.message);
         } finally {
             this.showLoading(false);
+            this.isLoadingTraining = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent repeated click binding in history manager
- guard against concurrent training loads
- retry history list request once after 60s timeout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687893702c38832a90e4266e2787f71b